### PR TITLE
Promote to prod environment

### DIFF
--- a/components/dotnet-basic-uhqrarfc/overlays/prod/deployment-patch.yaml
+++ b/components/dotnet-basic-uhqrarfc/overlays/prod/deployment-patch.yaml
@@ -12,5 +12,5 @@ spec:
   template: 
     spec:
       containers:
-      - image: quay.io/redhat-tssc/task-runner:1.7
+      - image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/dotnet-basic-uhqrarfc:github-e2669eb6552b3581f95b858dacb38b1ce884819c
         name: container-image  


### PR DESCRIPTION
This PR promotes the application to the prod environment with image: nexus-docker-nexus.apps.rosa.rhtap-services.xmdt.p3.openshiftapps.com/rhtap/dotnet-basic-uhqrarfc:github-e2669eb6552b3581f95b858dacb38b1ce884819c